### PR TITLE
fix formatting of utf-8 file with unicode

### DIFF
--- a/cmake_format.py
+++ b/cmake_format.py
@@ -310,7 +310,7 @@ class CmakeFormatEventListener(sublime_plugin.EventListener):
             if format_on_save:
                 # Saving file manually so cmake-format runs on new contents
                 body = view.substr(sublime.Region(0, view.size()))
-                with open(view.file_name(), "w") as f:
+                with open(view.file_name(), "w", encoding=input_encoding) as f:
                     f.write(body)
                     f.close()
 


### PR DESCRIPTION
Example of character that doesn't work before this commit: `─`
Error : UnicodeEncodeError: 'charmap' codec can't encode characters in positio
More info about this error on [stackoverflow](https://stackoverflow.com/questions/27092833/unicodeencodeerror-charmap-codec-cant-encode-characters/42495690#42495690)
Fix : https://github.com/jasjuang/sublime_cmake_format/issues/7