### PR TITLE
It should be `CMakeFormat` instead of `Cmakeformat`

### DIFF
--- a/cmake_format.py
+++ b/cmake_format.py
@@ -160,7 +160,7 @@ def load_settings():
     global input_encoding
     global output_encoding
     settings_global = sublime.load_settings(settings_file)
-    settings_local = sublime.active_window().active_view().settings().get('CmakeFormat', {})
+    settings_local = sublime.active_window().active_view().settings().get('CMakeFormat', {})
 
     def load(name, default): return settings_local.get(name, settings_global.get(name, default))
     # Load settings, with defaults.


### PR DESCRIPTION
This is probably a typo, but I noticed that the doc has mentioned `CMakeFormat` and what I did, I couldn't get it to work. After further investigation, I noticed that you are retrieving `CmakeFormat` instead and that causes the project dependent settings to not work properly. I have made a tiny change, and I think it should be enough, but you may wanna test it further. I like the `CMakeFormat` better, as you mentioned in the documentation.

P.S. You can probably also resolve this for good by forcing the key to be lower-cased.