### PR TITLE
It is "file", right?

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ Use
   to `"format_on_save": true`.
 - To change settings on a per-package basis, add them under `CMakeFormat` key,
   example project.sublime-settings:
-- To use style from a file (for example `.cmake-format`), change settings to `"style": "File"`. Otherwise `custom` style is used.
+- To use style from a file (for example `.cmake-format`), change settings to `"style": "file"`. Otherwise `custom` style is used.
 
 ```json
 {
   "folders": [],
   "settings": {
     "CMakeFormat": {
-      "style": "File",
+      "style": "file",
       "format_on_save": true
     }
   }


### PR DESCRIPTION
I'm not sure about this one, but I think it should be `file`, rather than `File`. It's `file` in the global setting file at least.